### PR TITLE
Fix exp and subexp when negative value is used

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,2 @@
+Germain Hebert
+germainhebert@ca.abb.com

--- a/spc/global_fun.py
+++ b/spc/global_fun.py
@@ -39,7 +39,9 @@ def read_subheader(subheader):
     subhead_str = "<cchfffiif4s"
     items = struct.unpack(subhead_str.encode('utf8'), subheader)
 
-    item_cpy = [ord(i) for i in items[:2]]
+    item_cpy = []
+    item_cpy.append(ord(items[0]))
+    item_cpy.append(struct.unpack('b', items[1])[0])
     item_cpy += items[2:]
 
     return item_cpy

--- a/spc/spc.py
+++ b/spc/spc.py
@@ -113,8 +113,8 @@ class File:
 
             # fix data types if necessary
             self.fnpts = int(self.fnpts)  # of points should be int
-            self.fexp = ord(self.fexp)
-
+            self.fexp = struct.unpack('b', self.fexp)[0]
+            
             self.ffirst = float(self.ffirst)
             self.flast = float(self.flast)
 


### PR DESCRIPTION
When exp or subexp is used with a negative value, the value in exp is wrong missing the sign.  Like -5 is 251. Given a wrong y axis value.